### PR TITLE
File Descriptor Leak through Import

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,7 @@
 
 #if !defined INPUT_LINE_SIZE
 // Max. line size is 8191 bytes.
-#define INPUT_LINE_SIZE 8192
+#define INPUT_LINE_SIZE 32768
 #endif
 
 // How many bytes to reserve for the output string


### PR DESCRIPTION
The 'fd' in do_import() was leaked. It caused an issue in a deployment where we were updating the data source every 15 minutes and tried to use the 'import' API to update the data source (without dumping the existing data).

The fix is to have a global 'if_fd' in place of the local 'fd' and close it before opening the file again in do_import.
