### PR TITLE
Add Darwin build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXXFLAGS=       -Wall $(COPT) -D_FILE_OFFSET_BITS=64
-LINKFLAGS=	-lm -lrt -pthread
+LINKFLAGS=	    -lm -pthread
 INCDEPS=        include/segtree.hpp include/sparsetable.hpp include/benderrmq.hpp \
                 include/phrase_map.hpp include/suggest.hpp include/types.hpp \
                 include/utils.hpp include/httpserver.hpp
@@ -7,6 +7,14 @@ INCDIRS=        -I . -I deps
 OBJDEPS=        src/httpserver.o deps/libuv/libuv.a
 HTTPSERVERDEPS= src/httpserver.cpp include/httpserver.hpp include/utils.hpp \
 		include/types.hpp
+
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+	CXXFLAGS += -DNORT
+	LINKFLAGS += -framework CoreFoundation -framework CoreServices
+else
+	LINKFLAGS += -lrt
+endif
 
 ifeq "$(findstring debug,$(MAKECMDGOALS))" ""
 OBJDEPS += deps/http-parser/http_parser.o


### PR DESCRIPTION
Linking flags required to build libuv: `-framework CoreFoundation -framework CoreServices`.